### PR TITLE
bluetooth: change tts.speak impatient param

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -139,13 +139,14 @@ module.exports = function (activity) {
 
   function speakAndBackground (text) {
     return activity.setForeground().then(() => {
-      activity.tts.speak(text, { impatient: true }).catch((err) => {
+      logger.debug(`Begin speak tts: ${text}`)
+      return activity.tts.speak(text, { impatient: false }).catch((err) => {
         /* Bluetooth music connect and open cut mode, it may be implement activity.destry,
         so After playing TTS, go back to the background. set up TTS impatient: true. */
         logger.error('bluetooth music tts error', err)
       })
     }).then(() => {
-      logger.debug(`check play_state = ${bluetoothMessage.play_state}`)
+      logger.debug(`After speak tts, check play_state to determine if setBackground: ${bluetoothMessage.play_state}`)
       if (bluetoothMessage.play_state !== 'played') {
         activity.setBackground()
       }


### PR DESCRIPTION
ISSUE: When listening cloud news, turn on bluetooth. After device connnected with a phone, the news app will be stopped.

ROOT CAUSE: Bluetooth event will call tts.speak with impatient = true, which will return immediately. And original design will continue call setBackground(), thus the news app will be resume at once. After tts received bluetooth's speak request, the news app's tts will be stopped.

SOLUTION: Change tts.speak with impatient = false, to avoid collision with other app's tts.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
