### PR TITLE
flora, test: set the timeout for flora loop tests

### DIFF
--- a/test/@yoda/flora/flora.test.js
+++ b/test/@yoda/flora/flora.test.js
@@ -510,7 +510,7 @@ test('module->flora->client: close post', t => {
 //
 // bug id = 1364
 //
-test.skip('module->flora->client: loop create connection', t => {
+test('module->flora->client: loop create connection', { timeout: 10 * 1000 }, t => {
   var clients = []
   for (var count = 0; count < 20; count++) {
     clients[count] = new Agent(okUri, reconnInterval, 0)
@@ -530,7 +530,7 @@ test.skip('module->flora->client: loop create connection', t => {
   }, 2000)
 })
 
-test('module->flora->client: loop post msg', t => {
+test('module->flora->client: loop post msg', { timeout: 10 * 1000 }, t => {
   var recvClient = new Agent(okUri, reconnInterval, 0)
   var count = 0
   for (var i = 0; i < 100; i++) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

This fixes the CI hang up at https://ci.rokid.com/view/Yodaos/job/rokid-ci-yodart-unit-tests/74/ which takes almost 30 minutes to run and failed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

/cc @mingzc0508 @cheongwen