### PR TITLE
fixed(cloudappclient): native directives should not preempt cloudappclient

### DIFF
--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -169,7 +169,8 @@ module.exports = activity => {
     var appId = _.get(dt, 'data.packageInfo.name', '')
     var form = _.get(dt, 'data.packageInfo.form', 'cut')
     var command = dt.data.command || ''
-    activity.openUrl(`yoda-skill://${appId}/?command=${command}`, form)
+    // Native directives should not preempt cloudAppclient
+    activity.openUrl(`yoda-skill://${appId}/?command=${command}`, { form: form, preemptive: false })
       .then(() => {
         logger.log('url open success')
         next()


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

This patch fixes the problem that the alarm reminder failed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
