### PR TITLE
alarm: fix month error

### DIFF
--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -294,8 +294,9 @@ AlarmCore.prototype._taskCallback = function (option, mode) {
  * @param {String} Options mode
  */
 AlarmCore.prototype._onTaskActive = function (option, mode) {
-  this.activeOption = option
+  this.clearAll()
   this.activity.setForeground().then(() => {
+    this.activeOption = option
     this._preventEventsDefaults()
     this._controlVolume(10, 1000, 7)
     var state = wifi.getNetworkState()

--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -235,7 +235,7 @@ AlarmCore.prototype._taskCallback = function (option, mode) {
   var state = wifi.getNetworkState()
 
   if (option.type === 'Remind') {
-    var sameReminder = this.scheduleHandler.combineReminderTts()
+    var sameReminder = this.scheduleHandler.combineReminderTts(this.activeOption.id)
     tts = sameReminder.combinedTTS
     this.activity.setForeground().then(() => {
       if (state === wifi.NETSERVER_CONNECTED) {

--- a/apps/alarm/expression.js
+++ b/apps/alarm/expression.js
@@ -347,7 +347,7 @@ CronExpression.prototype._findSchedule = function () {
   // Iterate and match schedule
   while (true) {
     // Match month
-    if (!matchSchedule(current.getMonth(), this._fields.month)) {
+    if (!matchSchedule(current.getMonth() + 1, this._fields.month)) {
       current.addMonth()
       current.setDate(1)
       current.setHours(0)
@@ -479,7 +479,7 @@ CronExpression.parseSync = function (expression, options) {
   }
 
   if (!options.currentDate) {
-    options.currentDate = new Date()
+    options.currentDate = new Date((new Date()).getTime() - 7000)
   }
 
   // Is input expression predefined?

--- a/apps/alarm/node-cron.js
+++ b/apps/alarm/node-cron.js
@@ -65,7 +65,6 @@ module.exports = (function () {
       var reminderList = []
       for (var i = 0; i < sortQueue.length; i++) {
         var jobObj = self.jobs[sortQueue[i]]
-        
         if (jobObj) {
           var currentObj = {
             type: self.jobs[activeId].type,
@@ -90,7 +89,6 @@ module.exports = (function () {
               date: jobObj.date
             })
           }
-          
         }
       }
       return {

--- a/apps/alarm/node-cron.js
+++ b/apps/alarm/node-cron.js
@@ -54,7 +54,7 @@ module.exports = (function () {
      *
      * @returns {string} combined tts.
      */
-    this.combineReminderTts = function () {
+    this.combineReminderTts = function (activeId) {
       if (self.reminderQueue.length === 0) {
         return ''
       }
@@ -65,18 +65,32 @@ module.exports = (function () {
       var reminderList = []
       for (var i = 0; i < sortQueue.length; i++) {
         var jobObj = self.jobs[sortQueue[i]]
+        
         if (jobObj) {
-          combinedTTS += jobObj.tts
-          reminderList.push({
-            id: jobObj.id,
-            createTime: jobObj.createTime,
+          var currentObj = {
+            type: self.jobs[activeId].type,
+            expression: self.jobs[activeId].expression,
+            createTime: self.jobs[activeId].createTime
+          }
+          var referedObj = {
             type: jobObj.type,
-            tts: jobObj.tts,
-            url: jobObj.url,
-            mode: jobObj.mode,
-            time: jobObj.time,
-            date: jobObj.date
-          })
+            expression: jobObj.expression,
+            createTime: jobObj.createTime
+          }
+          if (!clearPrevReminders(currentObj, referedObj)) {
+            combinedTTS += jobObj.tts
+            reminderList.push({
+              id: jobObj.id,
+              createTime: jobObj.createTime,
+              type: jobObj.type,
+              tts: jobObj.tts,
+              url: jobObj.url,
+              mode: jobObj.mode,
+              time: jobObj.time,
+              date: jobObj.date
+            })
+          }
+          
         }
       }
       return {


### PR DESCRIPTION
fix alram bugs
1. Month error: it will endless loop when now is on December.
2. It should not combine all tts in queue.

##### Checklist

- [ alarm-core ] add clear before alarm start. It should clear prev alarm when alarm is breaked.
- [ node-cron ] update `combineReminderTts`. it should not combine all tts in queue, just combine tts with same time.
- [ expression ] In JS, `getMonth` return 0 - 11, It will be endless loop when now is on December.
