### PR TITLE
Normalize license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,17 +1,4 @@
-Copyright 2018-present Rokid Co., Ltd. and other contributors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+Copyright Rokid Co., Ltd. and other contributors, https://www.rokid.com
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
Follow normal apache-2.0 license formats to enable GitHub and other tools license detection.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
